### PR TITLE
(Refactor) power operator usage

### DIFF
--- a/admin/ipsearch.php
+++ b/admin/ipsearch.php
@@ -54,7 +54,7 @@ if ($ip) {
                 $HTMLOUT.= stdmsg($lang['ipsearch_error'], $lang['ipsearch_subnet']);
                 echo stdhead("IP Search") . $HTMLOUT . stdfoot();
                 die();
-            } else $mask = long2ip(pow(2, 32) - pow(2, 32 - $n));
+            } else $mask = long2ip((2 ** 32) - (2 ** (32 - $n)));
         } elseif (!preg_match($regex, $mask)) {
             $HTMLOUT.= stdmsg($lang['ipsearch_error'], $lang['ipsearch_subnet']);
             echo stdhead("IP Search") . $HTMLOUT . stdfoot();

--- a/admin/mysql_overview.php
+++ b/admin/mysql_overview.php
@@ -60,13 +60,13 @@ $GLOBALS["byteUnits"] = array(
 );
 function byteformat($value, $limes = 2, $comma = 0)
 {
-    $dh = pow(10, $comma);
-    $li = pow(10, $limes);
+    $dh = 10 ** $comma;
+    $li = 10 ** $limes;
     $return_value = $value;
     $unit = $GLOBALS['byteUnits'][0];
     for ($d = 6, $ex = 15; $d >= 1; $d--, $ex-= 3) {
-        if (isset($GLOBALS['byteUnits'][$d]) && $value >= $li * pow(10, $ex)) {
-            $value = round($value / (pow(1024, $d) / $dh)) / $dh;
+        if (isset($GLOBALS['byteUnits'][$d]) && $value >= $li * (10 ** $ex)) {
+            $value = round($value / ((1024 ** $d) / $dh)) / $dh;
             $unit = $GLOBALS['byteUnits'][$d];
             break 1;
         } // end if

--- a/admin/mysql_stats.php
+++ b/admin/mysql_stats.php
@@ -67,13 +67,13 @@ $timespanfmt = '%s days, %s hours, %s minutes and %s seconds';
 ////////////////// FUNCTION LIST /////////////////////////
 function byteformat($value, $limes = 2, $comma = 0)
 {
-    $dh = pow(10, $comma);
-    $li = pow(10, $limes);
+    $dh = 10 ** $comma;
+    $li = 10 ** $limes;
     $return_value = $value;
     $unit = $GLOBALS['byteUnits'][0];
     for ($d = 6, $ex = 15; $d >= 1; $d--, $ex-= 3) {
-        if (isset($GLOBALS['byteUnits'][$d]) && $value >= $li * pow(10, $ex)) {
-            $value = round($value / (pow(1024, $d) / $dh)) / $dh;
+        if (isset($GLOBALS['byteUnits'][$d]) && $value >= $li * (10 ** $ex)) {
+            $value = round($value / ((1024 ** $d) / $dh)) / $dh;
             $unit = $GLOBALS['byteUnits'][$d];
             break 1;
         } // end if

--- a/admin/usersearch.php
+++ b/admin/usersearch.php
@@ -435,7 +435,7 @@ if (count($_POST) > 0); //&& isset($_POST['n']))
                     stdmsg($lang['usersearch_error'], $lang['usersearch_badmask']);
                     stdfoot();
                     die();
-                } else $mask = long2ip(pow(2, 32) - pow(2, 32 - $n));
+                } else $mask = long2ip((2 ** 32) - (2 ** (32 - $n)));
             } elseif (!preg_match($regex, $mask)) {
                 stdmsg($lang['usersearch_error'], $lang['usersearch_badmask']);
                 stdfoot();

--- a/vendor/matthiasmullie/scrapbook/src/Adapters/MemoryStore.php
+++ b/vendor/matthiasmullie/scrapbook/src/Adapters/MemoryStore.php
@@ -379,7 +379,7 @@ class MemoryStore implements KeyValueStore
             return $shorthand;
         }
 
-        $units = array('B' => 1024, 'M' => pow(1024, 2), 'G' => pow(1024, 3));
+        $units = array('B' => 1024, 'M' => 1024 ** 2, 'G' => 1024 ** 3);
 
         return (int) preg_replace_callback('/^([0-9]+)('.implode('|', array_keys($units)).')$/', function ($match) use ($units) {
             return $match[1] * $units[$match[2]];


### PR DESCRIPTION
- It's possible to use '$base ** $power' instead of 'pow($base, $power)' since PHP 5.6.